### PR TITLE
MDLSITE-1632 Prevent filtering into tags and links.

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -35,22 +35,20 @@ class filter_moodlelinks extends moodle_text_filter {
         'download page' => array('<a title="Auto-link" href="http://download.moodle.org/">', true, false),
 
         // With this being full-match
-        'Using Moodle' => array('<a title="Auto-link" href="http://moodle.org/course/view.php?id=5">', true, true),
+        'Using Moodle' => array('<a title="Auto-link" href="https://moodle.org/course/view.php?id=5">', true, true),
 
         // The rest are case-insensitive and full-match (and using forced phrase)
         'moodle roadmap' => array('<a title="Auto-link" href="http://docs.moodle.org/dev/Roadmap">', false, true, 'Moodle Roadmap'),
-        'moodle themes' => array('<a title="Auto-link" href="http://moodle.org/themes">', false, true, 'Moodle Themes'),
-        'moodle partners' => array('<a title="Auto-link" href="http://moodle.com/partners/">', false, true, 'Moodle Partners'),
-        'moodle partner' => array('<a title="Auto-link" href="http://moodle.com/partners/">', false, true, 'Moodle Partner'),
-        'moodle tracker' => array('<a title="Auto-link" href="http://tracker.moodle.org/">', false, true, 'Moodle Tracker'),
-        'moodle jobs' => array('<a title="Auto-link" href="http://moodle.org/jobs">', false, true, 'Moodle jobs'),
-        'moodle books' => array('<a title="Auto-link" href="http://moodle.org/books">', false, true, 'Moodle books'),
-        'mooch' => array('<a title="Moodle.org Open Community Hub" href="http://hub.moodle.org/">', false, true, 'MOOCH'),
-        'planet moodle' => array('<a title="Auto-link" href="http://planet.moodle.org/">', false, true, 'Planet Moodle'),
-        'moodle plugins' => array('<a title="Auto-link" href="http://moodle.org/plugins/">', false, true, 'Moodle plugins'),
-        'plugins directory' => array('<a title="Auto-link" href="http://moodle.org/plugins/">', false, true, 'Plugins directory'),
-
-
+        'moodle themes' => array('<a title="Auto-link" href="https://moodle.org/themes">', false, true, 'Moodle Themes'),
+        'moodle partners' => array('<a title="Auto-link" href="http://moodle.com/partners">', false, true, 'Moodle Partners'),
+        'moodle partner' => array('<a title="Auto-link" href="http://moodle.com/partners">', false, true, 'Moodle Partner'),
+        'moodle tracker' => array('<a title="Auto-link" href="https://tracker.moodle.org">', false, true, 'Moodle Tracker'),
+        'moodle jobs' => array('<a title="Auto-link" href="https://moodle.org/jobs">', false, true, 'Moodle jobs'),
+        'moodle books' => array('<a title="Auto-link" href="https://moodle.org/books">', false, true, 'Moodle books'),
+        'mooch' => array('<a title="Moodle.org Open Community Hub" href="http://hub.moodle.org">', false, true, 'MOOCH'),
+        'planet moodle' => array('<a title="Auto-link" href="http://planet.moodle.org">', false, true, 'Planet Moodle'),
+        'moodle plugins' => array('<a title="Auto-link" href="https://moodle.org/plugins">', false, true, 'Moodle plugins'),
+        'plugins directory' => array('<a title="Auto-link" href="https://moodle.org/plugins">', false, true, 'Plugins directory'),
     );
 
     public function filter($text, array $options = array()) {
@@ -101,7 +99,7 @@ class filter_moodlelinks extends moodle_text_filter {
                   '(?![^<]*</a>)' . // Try to avoid matching inside another link. Can be fooled by HTML like: <a href="..."><b>MDL-123</b></a>.
                   '#';
         $text = preg_replace($regexp,
-                '<a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/$0">$0</a>',
+                '<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/$0">$0</a>',
                 $text);
 
         // New regexp from Matteo Scaramuccia, based on Tim's one above (MDLSITE-1146) for better handling "Bug XXXX" matches.
@@ -112,7 +110,7 @@ class filter_moodlelinks extends moodle_text_filter {
                   '(?![^<]*</a>)' . // Try to avoid matching inside another link. Can be fooled by HTML like: <a href="..."><b>Bug #123</b></a>.
                   '$i';
         $text = preg_replace($regexp,
-                '<a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDL-$1">$0</a>',
+                '<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-$1">$0</a>',
                 $text);
 
         return $text;

--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -47,21 +47,22 @@ class filter_moodlelinks_testcase extends basic_testcase {
             'Adownload MOODLEZ' => 'Adownload MOODLEZ', // Not replaced, case-sensitive search
             'Adownload pageZ' => 'A<a title="Auto-link" href="http://download.moodle.org/">download page</a>Z',
             'Adownload PAGEZ' => 'Adownload PAGEZ', // Not replaced, case-sensitive search
-            'A Using Moodle,' => 'A <a title="Auto-link" href="http://moodle.org/course/view.php?id=5">Using Moodle</a>,',
+            'A Using Moodle,' => 'A <a title="Auto-link" href="https://moodle.org/course/view.php?id=5">Using Moodle</a>,',
             'A Using MoodleZ' => 'A Using MoodleZ', // Not replaced, full-match search
             'A Using MOODLE' => 'A Using MOODLE', // Not replaced, case-sensitive search
             'A MOODLE roadmap.' => 'A <a title="Auto-link" href="http://docs.moodle.org/dev/Roadmap">Moodle Roadmap</a>.',
             'A MOODLE roadmapZ' => 'A MOODLE roadmapZ', // Not replaced, full-match search
             'AAMOODLE roadmap' => 'AAMOODLE roadmap', // Not replaced, full-match search
-            'A MOODLE themes.' => 'A <a title="Auto-link" href="http://moodle.org/themes">Moodle Themes</a>.',
-            'A MOODLE partners,' => 'A <a title="Auto-link" href="http://moodle.com/partners/">Moodle Partners</a>,',
-            'A MOODLE partner:' => 'A <a title="Auto-link" href="http://moodle.com/partners/">Moodle Partner</a>:',
-            'A MOODLE jobs/' => 'A <a title="Auto-link" href="http://moodle.org/jobs">Moodle jobs</a>/',
-            '.MOODLE books' => '.<a title="Auto-link" href="http://moodle.org/books">Moodle books</a>',
-            ',MoocH' => ',<a title="Moodle.org Open Community Hub" href="http://hub.moodle.org/">MOOCH</a>',
-            ' planet MOODLE' => ' <a title="Auto-link" href="http://planet.moodle.org/">Planet Moodle</a>',
-            ': MOODLE plugins' => ': <a title="Auto-link" href="http://moodle.org/plugins/">Moodle plugins</a>',
-            '[plugins DIRECTORY)' => '[<a title="Auto-link" href="http://moodle.org/plugins/">Plugins directory</a>)',
+            'A MOODLE themes.' => 'A <a title="Auto-link" href="https://moodle.org/themes">Moodle Themes</a>.',
+            'A MOODLE partners,' => 'A <a title="Auto-link" href="http://moodle.com/partners">Moodle Partners</a>,',
+            'A MOODLE partner:' => 'A <a title="Auto-link" href="http://moodle.com/partners">Moodle Partner</a>:',
+            'A MOODLE trackeR:' => 'A <a title="Auto-link" href="https://tracker.moodle.org">Moodle Tracker</a>:',
+            'A MOODLE jobs/' => 'A <a title="Auto-link" href="https://moodle.org/jobs">Moodle jobs</a>/',
+            '.MOODLE books' => '.<a title="Auto-link" href="https://moodle.org/books">Moodle books</a>',
+            ',MoocH' => ',<a title="Moodle.org Open Community Hub" href="http://hub.moodle.org">MOOCH</a>',
+            ' planet MOODLE' => ' <a title="Auto-link" href="http://planet.moodle.org">Planet Moodle</a>',
+            ': MOODLE plugins' => ': <a title="Auto-link" href="https://moodle.org/plugins">Moodle plugins</a>',
+            '[plugins DIRECTORY)' => '[<a title="Auto-link" href="https://moodle.org/plugins">Plugins directory</a>)',
             // Verify MDLSITE-1632 (replacements into tags and links) is fixed.
             '<a title="to Moodle Tracker" href="">MDLSITE-111</a>' => '<a title="to Moodle Tracker" href="">MDLSITE-111</a>',
             '<a title="Auto-link" href="">to Moodle Tracker</a>' => '<a title="Auto-link" href="">to Moodle Tracker</a>'
@@ -93,19 +94,19 @@ class filter_moodlelinks_testcase extends basic_testcase {
             '<a href="http://example.com/a/very/very/long/url/containing/MDL-123"><br />MDL-123</a>' => '<a href="http://example.com/a/very/very/long/url/containing/MDL-123"><br />MDL-123</a>',
 
             // A known limit of the regexp, we have to live with it (unless somebody fixes it without breaking the rest)
-            'search Google for <a href="http://www.google.com.au/"><b>MDLSITE-0</b></a>' => 'search Google for <a href="http://www.google.com.au/"><b><a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDLSITE-0">MDLSITE-0</a></b></a>',
+            'search Google for <a href="http://www.google.com.au/"><b>MDLSITE-0</b></a>' => 'search Google for <a href="http://www.google.com.au/"><b><a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDLSITE-0">MDLSITE-0</a></b></a>',
 
             // Replaced cases by Tim's regexp
-            'MDL-123' => '<a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDL-123">MDL-123</a>',
-            'MDLSITE-0' => '<a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDLSITE-0">MDLSITE-0</a>',
-            'CONTRIB-1234567890' => '<a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/CONTRIB-1234567890">CONTRIB-1234567890</a>',
-            '<b>MDL-123</b>' => '<b><a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDL-123">MDL-123</a></b>',
-            'See MDL-1 for details!' => 'See <a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDL-1">MDL-1</a> for details!',
-            'http://www.google.com.au/search?q=MDL-1' => 'http://www.google.com.au/search?q=<a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDL-1">MDL-1</a>',
-            '<a href="http://example.com">Link</a>http://www.google.com.au/search?q=MDL-123' => '<a href="http://example.com">Link</a>http://www.google.com.au/search?q=<a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDL-123">MDL-123</a>',
-            'search for MDL-123 on <a href="http://www.google.com.au/">Google</a>' => 'search for <a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDL-123">MDL-123</a> on <a href="http://www.google.com.au/">Google</a>',
-            '<br /> This should be working - MDL-123. Please vote for it if you\'d like... <br />' => '<br /> This should be working - <a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDL-123">MDL-123</a>. Please vote for it if you\'d like... <br />',
-            "The bug 'MDL-123' is > (more serious than)" => "The bug '<a title=\"Auto-link to Moodle Tracker\" href=\"http://tracker.moodle.org/browse/MDL-123\">MDL-123</a>' is > (more serious than)",
+            'MDL-123' => '<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">MDL-123</a>',
+            'MDLSITE-0' => '<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDLSITE-0">MDLSITE-0</a>',
+            'CONTRIB-1234567890' => '<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/CONTRIB-1234567890">CONTRIB-1234567890</a>',
+            '<b>MDL-123</b>' => '<b><a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">MDL-123</a></b>',
+            'See MDL-1 for details!' => 'See <a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-1">MDL-1</a> for details!',
+            'http://www.google.com.au/search?q=MDL-1' => 'http://www.google.com.au/search?q=<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-1">MDL-1</a>',
+            '<a href="http://example.com">Link</a>http://www.google.com.au/search?q=MDL-123' => '<a href="http://example.com">Link</a>http://www.google.com.au/search?q=<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">MDL-123</a>',
+            'search for MDL-123 on <a href="http://www.google.com.au/">Google</a>' => 'search for <a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">MDL-123</a> on <a href="http://www.google.com.au/">Google</a>',
+            '<br /> This should be working - MDL-123. Please vote for it if you\'d like... <br />' => '<br /> This should be working - <a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">MDL-123</a>. Please vote for it if you\'d like... <br />',
+            "The bug 'MDL-123' is > (more serious than)" => "The bug '<a title=\"Auto-link to Moodle Tracker\" href=\"https://tracker.moodle.org/browse/MDL-123\">MDL-123</a>' is > (more serious than)",
 
             // Not replaced by the sister (Bug XXXXX) regexp to the tracker. MDLSITE-1146
             'Bug 123X' => 'Bug 123X',
@@ -113,11 +114,11 @@ class filter_moodlelinks_testcase extends basic_testcase {
             '<a   href="http://www.google.com.au/">Look for Bug 123</a>' => '<a   href="http://www.google.com.au/">Look for Bug 123</a>',
 
             // Replaced by the sister (Bug XXXXX) regexp to the tracker. MDLSITE-1146
-            'Bug 123' => '<a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDL-123">Bug 123</a>',
-            'Bug #123' => '<a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDL-123">Bug #123</a>',
-            'bUg 123' => '<a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDL-123">bUg 123</a>',
-            '<b>Bug 123</b>' => '<b><a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDL-123">Bug 123</a></b>',
-            'http://www.google.com.au/search?q=Bug 123' => 'http://www.google.com.au/search?q=<a title="Auto-link to Moodle Tracker" href="http://tracker.moodle.org/browse/MDL-123">Bug 123</a>'
+            'Bug 123' => '<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">Bug 123</a>',
+            'Bug #123' => '<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">Bug #123</a>',
+            'bUg 123' => '<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">bUg 123</a>',
+            '<b>Bug 123</b>' => '<b><a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">Bug 123</a></b>',
+            'http://www.google.com.au/search?q=Bug 123' => 'http://www.google.com.au/search?q=<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">Bug 123</a>'
         );
 
         $filter = new testable_filter_moodlelinks();


### PR DESCRIPTION
This filter was using some simple str_[i]replace() calls
to perform replacements in all moodle.org contents. That
was leading to problems here and there when the target texts
were used within tags (borking) or links (double links).

As far as it's really hard to compute those cases using an
unique regexp, now the filter is relying into the core
filter_phrases() function (used by the glossary, data... filters)
able to properly avoid those tags and links and, at the same time,
also provide accurate support for case-sensitive and full-matches.

Note that there are some slightly modifications in tests, all them
to properly cover the "full-match" mode, that previously was, simply,
not working at all.

Finally note that, with this change, we have tried to observe the
old links behavior completely by forcing some phrases here and there.
Surely it will be more "natural" to, always, preserve the original
casing typed by the user (perhaps "MOOCH" can be
the unique exception with some sense).

This can be easily achieved by taking out all the "forcephrase"
parameters in the $links property of the filter. But in any case
it's not the goal of this issue, so I've prefered to keep the
resulting phrases the same.
