### PR TITLE
MDLSITE-7948: Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Moodlelinks filter
 ==================
 
-The filter creates links to some very well known places at moodle.org (cvs, tracker, downloads...)
+The filter creates links to some very well known places at moodle.org (cloud, tracker, downloads...)

--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -30,34 +30,30 @@ class text_filter extends \core_filters\text_filter {
     // Format: phrase => array(<a> tag, casesensitive, fullmatch, forcephrase).
     protected $links = array(
         // Some are case-sensitive, non full-match
-        'Moodle download' => array('<a title="Auto-link" href="http://download.moodle.org/">', true, false),
-        'download Moodle' => array('<a title="Auto-link" href="http://download.moodle.org/">', true, false),
-        'download page' => array('<a title="Auto-link" href="http://download.moodle.org/">', true, false),
+        'Moodle download' => array('<a title="Auto-link" href="https://download.moodle.org/">', true, false),
+        'download Moodle' => array('<a title="Auto-link" href="https://download.moodle.org/">', true, false),
+        'download page' => array('<a title="Auto-link" href="https://download.moodle.org/">', true, false),
 
         // With this being full-match
         //'Using Moodle' => array('<a title="Auto-link" href="https://moodle.org/course/view.php?id=5">', true, true),
 
         // The rest are case-insensitive and full-match (and using forced phrase)
-        'moodle roadmap' => array('<a title="Auto-link" href="http://docs.moodle.org/dev/Roadmap">', false, true, 'Moodle Roadmap'),
+        'moodle roadmap' => array('<a title="Auto-link" href="https://moodledev.io/general/community/roadmap">', false, true, 'Moodle Roadmap'),
         'moodle themes' => array('<a title="Auto-link" href="https://moodle.org/themes">', false, true, 'Moodle Themes'),
-        'moodle partners' => array('<a title="Auto-link" href="http://moodle.com/partners">', false, true, 'Moodle Partners'),
-        'moodle partner' => array('<a title="Auto-link" href="http://moodle.com/partners">', false, true, 'Moodle Partner'),
+        'moodle partners' => array('<a title="Auto-link" href="https://moodle.com/partners">', false, true, 'Moodle Partners'),
+        'moodle partner' => array('<a title="Auto-link" href="https://moodle.com/partners">', false, true, 'Moodle Partner'),
         'moodle tracker' => array('<a title="Auto-link" href="https://tracker.moodle.org">', false, true, 'Moodle Tracker'),
         'moodle jobs' => array('<a title="Auto-link" href="https://moodle.org/jobs">', false, true, 'Moodle jobs'),
         'moodle books' => array('<a title="Auto-link" href="https://moodle.org/books">', false, true, 'Moodle books'),
         'mooch' => array('<a title="MoodleNet - Connecting and empowering educators worldwide" href="https://moodle.net">', false, true),
         'moodle.net' => array('<a title="MoodleNet - Connecting and empowering educators worldwide" href="https://moodle.net">', false, true),
         'moodlenet' => array('<a title="MoodleNet - Connecting and empowering educators worldwide" href="https://moodle.net">', false, true),
-        'planet moodle' => array('<a title="Auto-link" href="http://planet.moodle.org">', false, true, 'Planet Moodle'),
         'moodle plugins' => array('<a title="Auto-link" href="https://moodle.org/plugins">', false, true, 'Moodle plugins'),
         'plugins directory' => array('<a title="Auto-link" href="https://moodle.org/plugins">', false, true, 'Plugins directory'),
-        'moodlecloud' => array('<a title="Auto-link" href="https://moodle.com/cloud/">', false, true, 'MoodleCloud'),
-        'Moodle Users Association' => array('<a title="Auto-link" href="https://moodleassociation.org/">', false, true, 'Moodle Users Association'),
+        'moodlecloud' => array('<a title="Auto-link" href="https://moodlecloud.com/">', false, true, 'MoodleCloud'),
         'moodle academy' => array('<a title="The learning hub for the global Moodle community" href="https://moodle.academy/">', false, true, 'Moodle Academy'),
         'moodle.academy' => array('<a title="The learning hub for the global Moodle community" href="https://moodle.academy/">', false, true, 'Moodle.Academy'),
 
-        // Some case-sensitive abbrevs, full matched.
-        'MUA' => array('<a title="Auto-link" href="https://moodleassociation.org/">', true, true),
     );
 
     public function filter($text, array $options = array()) {
@@ -91,12 +87,6 @@ class text_filter extends \core_filters\text_filter {
 
         // Let's filter all the filter objects.
         $text = filter_phrases($text, $linklist);
-
-        // Some legacy links to the cvs repository.
-        // TODO: Take them out once the cvs repo is down.
-        $text = preg_replace("|cvs:/([[:alnum:]\./_-]*)([[:alnum:]/])|i",
-                "<a title=\"Auto-link to Moodle CVS repository\" href=\"http://cvs.moodle.org/\\1\\2\">cvs:/$1$2</a>",
-                $text);
 
         // TODO: Add links to the git repository
 

--- a/tests/text_filter_test.php
+++ b/tests/text_filter_test.php
@@ -30,7 +30,7 @@ global $CFG;
 /**
  * Moodle links filter testcase
  */
-class filter_moodlelinks_testcase extends basic_testcase {
+class text_filter_test extends basic_testcase {
 
     /**
      * Test some simple replaces, some case-sensitive, others no...
@@ -40,34 +40,30 @@ class filter_moodlelinks_testcase extends basic_testcase {
         // processed by the better filter_phrases() stuff. Results are 99% the
         // original ones but now we avoid replacing into tags and links.
         $texts = array(
-            'AMoodle downloadZ' => 'A<a title="Auto-link" href="http://download.moodle.org/">Moodle download</a>Z',
+            'AMoodle downloadZ' => 'A<a title="Auto-link" href="https://download.moodle.org/">Moodle download</a>Z',
             'AMOODLE downloadZ' => 'AMOODLE downloadZ', // Not replaced, case-sensitive search
-            'Adownload MoodleZ' => 'A<a title="Auto-link" href="http://download.moodle.org/">download Moodle</a>Z',
+            'Adownload MoodleZ' => 'A<a title="Auto-link" href="https://download.moodle.org/">download Moodle</a>Z',
             'Adownload MOODLEZ' => 'Adownload MOODLEZ', // Not replaced, case-sensitive search
-            'Adownload pageZ' => 'A<a title="Auto-link" href="http://download.moodle.org/">download page</a>Z',
+            'Adownload pageZ' => 'A<a title="Auto-link" href="https://download.moodle.org/">download page</a>Z',
             'Adownload PAGEZ' => 'Adownload PAGEZ', // Not replaced, case-sensitive search
             'A Using Moodle,' => 'A Using Moodle,',
             'A Using MoodleZ' => 'A Using MoodleZ', // Not replaced, full-match search
             'A Using MOODLE' => 'A Using MOODLE', // Not replaced, case-sensitive search
-            'A MOODLE roadmap.' => 'A <a title="Auto-link" href="http://docs.moodle.org/dev/Roadmap">Moodle Roadmap</a>.',
+            'A MOODLE roadmap.' => 'A <a title="Auto-link" href="https://moodledev.io/general/community/roadmap">Moodle Roadmap</a>.',
             'A MOODLE roadmapZ' => 'A MOODLE roadmapZ', // Not replaced, full-match search
             'AAMOODLE roadmap' => 'AAMOODLE roadmap', // Not replaced, full-match search
             'A MOODLE themes.' => 'A <a title="Auto-link" href="https://moodle.org/themes">Moodle Themes</a>.',
-            'A MOODLE partners,' => 'A <a title="Auto-link" href="http://moodle.com/partners">Moodle Partners</a>,',
-            'A MOODLE partner:' => 'A <a title="Auto-link" href="http://moodle.com/partners">Moodle Partner</a>:',
+            'A MOODLE partners,' => 'A <a title="Auto-link" href="https://moodle.com/partners">Moodle Partners</a>,',
+            'A MOODLE partner:' => 'A <a title="Auto-link" href="https://moodle.com/partners">Moodle Partner</a>:',
             'A MOODLE trackeR:' => 'A <a title="Auto-link" href="https://tracker.moodle.org">Moodle Tracker</a>:',
             'A MOODLE jobs/' => 'A <a title="Auto-link" href="https://moodle.org/jobs">Moodle jobs</a>/',
             '.MOODLE books' => '.<a title="Auto-link" href="https://moodle.org/books">Moodle books</a>',
             ',MoocH' => ',<a title="MoodleNet - Connecting and empowering educators worldwide" href="https://moodle.net">MoocH</a>',
             'MoOdLe.NeT' => '<a title="MoodleNet - Connecting and empowering educators worldwide" href="https://moodle.net">MoOdLe.NeT</a>',
             'MoodleNET' => '<a title="MoodleNet - Connecting and empowering educators worldwide" href="https://moodle.net">MoodleNET</a>',
-            ' planet MOODLE' => ' <a title="Auto-link" href="http://planet.moodle.org">Planet Moodle</a>',
             ': MOODLE plugins' => ': <a title="Auto-link" href="https://moodle.org/plugins">Moodle plugins</a>',
             '[plugins DIRECTORY)' => '[<a title="Auto-link" href="https://moodle.org/plugins">Plugins directory</a>)',
-            'see moodlecloud for details' => 'see <a title="Auto-link" href="https://moodle.com/cloud/">MoodleCloud</a> for details',
-            'The moodle users association.' => 'The <a title="Auto-link" href="https://moodleassociation.org/">Moodle Users Association</a>.',
-            ',MUA site.' => ',<a title="Auto-link" href="https://moodleassociation.org/">MUA</a> site.',
-            'East Midlands Universities Association (EMUA)' => 'East Midlands Universities Association (EMUA)',
+            'see moodlecloud for details' => 'see <a title="Auto-link" href="https://moodlecloud.com/">MoodleCloud</a> for details',
             // Verify MDLSITE-1632 (replacements into tags and links) is fixed.
             '<a title="to Moodle Tracker" href="">MDLSITE-111</a>' => '<a title="to Moodle Tracker" href="">MDLSITE-111</a>',
             '<a title="Auto-link" href="">to Moodle Tracker</a>' => '<a title="Auto-link" href="">to Moodle Tracker</a>',
@@ -93,36 +89,36 @@ class filter_moodlelinks_testcase extends basic_testcase {
         $texts = array(
             // Not replaced cases by Tim's regexp
             'MDL-123Z' => 'MDL-123Z',
-            '<a href="http://tracker.moodle.org/browse/CONTRIB-1234567890">CONTRIB-1234567890</a>' => '<a href="http://tracker.moodle.org/browse/CONTRIB-1234567890">CONTRIB-1234567890</a>',
-            "<a href  =    'http://tracker.moodle.org/browse/CONTRIB-1234567890'>CONTRIB-1234567890</a>" => "<a href  =    'http://tracker.moodle.org/browse/CONTRIB-1234567890'>CONTRIB-1234567890</a>",
-            '<a href="http://www.google.com.au/search?q=MDL-123">Google search</a>' => '<a href="http://www.google.com.au/search?q=MDL-123">Google search</a>',
-            '<a href = "http://www.google.com.au/search?q=MDL-123"><br />Google search</a>' => '<a href = "http://www.google.com.au/search?q=MDL-123"><br />Google search</a>',
-            '<a href="http://www.google.com.au/">go to Google and search for MDL-123</a>' => '<a href="http://www.google.com.au/">go to Google and search for MDL-123</a>',
-            '<a href="http://www.google.com.au/">search for MDL-123 on Google</a>' => '<a href="http://www.google.com.au/">search for MDL-123 on Google</a>',
-            '<a href="http://example.com/a/very/very/long/url/containing/MDL-123"><br />MDL-123</a>' => '<a href="http://example.com/a/very/very/long/url/containing/MDL-123"><br />MDL-123</a>',
+            '<a href="https://tracker.moodle.org/browse/CONTRIB-1234567890">CONTRIB-1234567890</a>' => '<a href="https://tracker.moodle.org/browse/CONTRIB-1234567890">CONTRIB-1234567890</a>',
+            "<a href  =    'https://tracker.moodle.org/browse/CONTRIB-1234567890'>CONTRIB-1234567890</a>" => "<a href  =    'https://tracker.moodle.org/browse/CONTRIB-1234567890'>CONTRIB-1234567890</a>",
+            '<a href="https://www.google.com.au/search?q=MDL-123">Google search</a>' => '<a href="https://www.google.com.au/search?q=MDL-123">Google search</a>',
+            '<a href = "https://www.google.com.au/search?q=MDL-123"><br />Google search</a>' => '<a href = "https://www.google.com.au/search?q=MDL-123"><br />Google search</a>',
+            '<a href="https://www.google.com.au/">go to Google and search for MDL-123</a>' => '<a href="https://www.google.com.au/">go to Google and search for MDL-123</a>',
+            '<a href="https://www.google.com.au/">search for MDL-123 on Google</a>' => '<a href="https://www.google.com.au/">search for MDL-123 on Google</a>',
+            '<a href="https://example.com/a/very/very/long/url/containing/MDL-123"><br />MDL-123</a>' => '<a href="https://example.com/a/very/very/long/url/containing/MDL-123"><br />MDL-123</a>',
 
             // A known limit of the regexp, we have to live with it (unless somebody fixes it without breaking the rest)
-            'search Google for <a href="http://www.google.com.au/"><b>MDLSITE-0</b></a>' => 'search Google for <a href="http://www.google.com.au/"><b><a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDLSITE-0">MDLSITE-0</a></b></a>',
+            'search Google for <a href="https://www.google.com.au/"><b>MDLSITE-0</b></a>' => 'search Google for <a href="https://www.google.com.au/"><b><a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDLSITE-0">MDLSITE-0</a></b></a>',
 
             // Replaced cases by Tim's regexp
             'MDL-123' => '<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">MDL-123</a>',
             '<b>MDL-123</b>' => '<b><a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">MDL-123</a></b>',
             'See MDL-1 for details!' => 'See <a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-1">MDL-1</a> for details!',
-            'http://www.google.com.au/search?q=MDL-1' => 'http://www.google.com.au/search?q=<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-1">MDL-1</a>',
-            '<a href="http://example.com">Link</a>http://www.google.com.au/search?q=MDL-123' => '<a href="http://example.com">Link</a>http://www.google.com.au/search?q=<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">MDL-123</a>',
-            'search for MDL-123 on <a href="http://www.google.com.au/">Google</a>' => 'search for <a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">MDL-123</a> on <a href="http://www.google.com.au/">Google</a>',
+            'https://www.google.com.au/search?q=MDL-1' => 'https://www.google.com.au/search?q=<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-1">MDL-1</a>',
+            '<a href="https://example.com">Link</a>https://www.google.com.au/search?q=MDL-123' => '<a href="https://example.com">Link</a>https://www.google.com.au/search?q=<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">MDL-123</a>',
+            'search for MDL-123 on <a href="https://www.google.com.au/">Google</a>' => 'search for <a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">MDL-123</a> on <a href="https://www.google.com.au/">Google</a>',
             '<br /> This should be working - MDL-123. Please vote for it if you\'d like... <br />' => '<br /> This should be working - <a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/MDL-123">MDL-123</a>. Please vote for it if you\'d like... <br />',
             "The bug 'MDL-123' is > (more serious than)" => "The bug '<a title=\"Auto-link to Moodle Tracker\" href=\"https://tracker.moodle.org/browse/MDL-123\">MDL-123</a>' is > (more serious than)",
 
             // The texts like 'bug #123' or 'bug 123' should not be processed (MDLSITE-4019).
             'Bug 123X' => 'Bug 123X',
             'Bug #123X' => 'Bug #123X',
-            '<a   href="http://www.google.com.au/">Look for Bug 123</a>' => '<a   href="http://www.google.com.au/">Look for Bug 123</a>',
+            '<a   href="https://www.google.com.au/">Look for Bug 123</a>' => '<a   href="https://www.google.com.au/">Look for Bug 123</a>',
             'Bug 123' => 'Bug 123',
             'Bug #123' => 'Bug #123',
             'bUg 123' => 'bUg 123',
             '<b>Bug 123</b>' => '<b>Bug 123</b>',
-            'http://www.google.com.au/search?q=Bug 123' => 'http://www.google.com.au/search?q=Bug 123',
+            'https://www.google.com.au/search?q=Bug 123' => 'https://www.google.com.au/search?q=Bug 123',
 
             // Links to other projects (CONTRIB, MDLSITE, MDLQA, MDLTEST, MOBILE)
             'CONTRIB-1234567890' => '<a title="Auto-link to Moodle Tracker" href="https://tracker.moodle.org/browse/CONTRIB-1234567890">CONTRIB-1234567890</a>',


### PR DESCRIPTION
Hi,
I applied different changes, updating URLs:

Delete:
- planet.moodle.org
- moodle association links
Update moodlecloud:
- From moodle.com/cloud to moodlecloud.com
Update roadmap:
- From docs.moodle.org/dev/Roadmap to moodledev.io/general/community/roadmap
Update HTTPS: 
- I have updated all the links that did not use https, to https.